### PR TITLE
Adiciona .gitignore e estrutura inicial do projeto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.egg-info/
+*.egg
+dist/
+build/
+eggs/
+*.whl
+
+# Virtual environments
+venv/
+env/
+.venv/
+.env
+
+# Jupyter Notebook
+.ipynb_checkpoints/
+
+# MLflow
+mlruns/
+mlartifacts/
+
+# Data
+#*.csv
+#*.parquet
+#*.h5
+#*.hdf5
+#data/
+
+# Model artifacts
+*.pt
+*.pth
+*.onnx
+models/
+
+# IDE - VSCode
+.vscode/
+
+# IDE - JetBrains (WebStorm, PyCharm, IntelliJ)
+.idea/
+*.iml
+*.iws
+*.ipr
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment variables
+.env
+.env.*
+
+# Claude Code
+CLAUDE.md
+.claude/
+
+# pytest / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# mypy
+.mypy_cache/
+
+# Logs
+*.log

--- a/src/register.py
+++ b/src/register.py
@@ -1,0 +1,3 @@
+# register.py - Responsável por registrar os artefatos do modelo treinado no MLflow,
+# promovendo para produção apenas se as métricas (acurácia, F1-Score, etc.)
+# forem melhores que as do modelo já em produção.

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,1 @@
+# train.py - Responsável por ler os dados e treinar o modelo de predição de churn.

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,1 @@
+# utils.py - Funções utilitárias compartilhadas entre os módulos do projeto.

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1,0 +1,3 @@
+# unit_tests.py - Testes unitários que validam o funcionamento das funções em train.py
+# e demais módulos do projeto, garantindo que o pipeline opera corretamente
+# antes do registro do modelo no MLflow.


### PR DESCRIPTION
Configura .gitignore para excluir artefatos de IDEs (VSCode, JetBrains), Python, MLflow e ambientes virtuais.
Cria estrutura de diretórios src/ e tests/ com comentários de responsabilidade em cada módulo (train, register, utils, unit_tests).