### PR TITLE
fix: adiciona --serve-artifacts ao MLflow para que a API baixe modelo…

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,9 +20,13 @@ services:
     # --allowed-hosts: permite requisições com Host "mlflow" (nome do serviço Docker).
     # O MLflow 2.10+ rejeita por padrão qualquer host que não seja localhost/127.0.0.1.
     # Seguro porque a porta não está exposta publicamente.
+    # --serve-artifacts: o servidor passa a servir artefatos via HTTP.
+    # Sem essa flag, o MLflow diz ao cliente o caminho local do artefato (ex:
+    # file:///mlflow/artifacts/...) e o cliente tenta acessar diretamente — o que
+    # falha no container da API, que não tem esse volume montado.
     # --allowed-hosts inclui "mlflow:5000" porque o header HTTP enviado pelos containers
     # inclui a porta (ex: "Host: mlflow:5000"), e o middleware faz match exato.
-    command: mlflow server --backend-store-uri sqlite:////mlflow/mlflow.db --default-artifact-root /mlflow/artifacts --host 0.0.0.0 --port 5000 --allowed-hosts mlflow,mlflow:5000,localhost,127.0.0.1
+    command: mlflow server --backend-store-uri sqlite:////mlflow/mlflow.db --default-artifact-root /mlflow/artifacts --host 0.0.0.0 --port 5000 --serve-artifacts --allowed-hosts mlflow,mlflow:5000,localhost,127.0.0.1
     healthcheck:
       # Verifica se o servidor MLflow está pronto para aceitar requisições.
       # Os serviços train e api aguardam esse healthcheck antes de iniciar.


### PR DESCRIPTION
…s via HTTP
Precisei usar --serve-artifacts: o servidor passa a servir artefatos via HTTP.
Sem essa flag, o MLflow diz ao cliente o caminho local do artefato (ex: file:///mlflow/artifacts/...) e o cliente tenta acessar diretamente — o que falha no container da API, que não tem esse volume montado.