### PR TITLE
fix: força recriação do container da API no deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -109,6 +109,6 @@ jobs:
               train python -m src.register_models
 
             echo "--- Fazendo deploy da API ---"
-            docker compose -f docker-compose.prod.yml up -d api
+            docker compose -f docker-compose.prod.yml up -d --force-recreate api
 
             echo "--- Deploy concluído ---"


### PR DESCRIPTION
Sem --force-recreate, o Docker Compose mantém o container em execução quando a hash de configuração não muda, ignorando a nova imagem gerada pelo build. A flag garante que a API sempre sobe com o código atualizado após cada deploy.