### PR TITLE
fix: para a API antes do treino para liberar RAM na VPS

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,6 +97,13 @@ jobs:
             # up -d é idempotente: não reinicia um container já em execução.
             docker compose -f docker-compose.prod.yml up -d mlflow
 
+            echo "--- Parando API antiga para liberar RAM durante o treino ---"
+            # A VPS tem RAM limitada e o treino da MLP carrega PyTorch (~1GB).
+            # Se a API antiga ficar rodando — especialmente em loop de restart
+            # quando o Registry ainda está vazio — o OOM killer mata o treino.
+            # "|| true" para não falhar o pipeline se o container ainda não existir.
+            docker compose -f docker-compose.prod.yml stop api || true
+
             echo "--- Treinando modelos ---"
             # O container train se comunica com o mlflow pela rede interna do Docker.
             # --rm remove o container após a execução.


### PR DESCRIPTION
A VPS tem 4GB de RAM e o treino da MLP carrega PyTorch (~1GB). Quando o Registry está vazio, a API entra em loop de restart e consome RAM continuamente, fazendo o OOM killer matar o treino. Parar a API antes do treino quebra esse ciclo e libera memória para o pico de uso. A API sobe novamente ao final, com os modelos já registrados.