### PR TITLE
feat: expõe porta do MLflow em 127.0.0.1 da VPS para acesso via SSH t…

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -87,6 +87,22 @@ docker compose -f docker-compose.prod.yml run --rm \
 docker compose -f docker-compose.prod.yml up -d api
 ```
 
+### Acessar o MLflow UI da VPS
+
+A porta do MLflow é exposta apenas em `127.0.0.1` da VPS (não acessível pela
+internet, pois o MLflow não tem autenticação). Para ver a UI a partir da sua
+máquina local, abra um túnel SSH:
+
+```bash
+ssh -L 5000:localhost:5000 <usuario>@82.29.57.75
+```
+
+Enquanto a sessão SSH estiver aberta, acesse no navegador:
+
+```
+http://localhost:5000
+```
+
 ### Após a primeira configuração
 
 Todo push na branch `main` dispara o pipeline CI/CD automaticamente:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,8 +10,13 @@
 services:
   mlflow:
     build: .
-    # Sem exposição de porta: o MLflow é acessível apenas dentro da rede Docker.
-    # Os containers train e api se comunicam via http://mlflow:5000 internamente.
+    # Porta exposta apenas em 127.0.0.1 da VPS — não acessível pela internet.
+    # Para ver a UI, abrir um túnel SSH a partir da máquina local:
+    #   ssh -L 5000:localhost:5000 <user>@<vps-host>
+    # e depois acessar http://localhost:5000 no navegador.
+    # Os containers train e api continuam usando http://mlflow:5000 pela rede Docker.
+    ports:
+      - "127.0.0.1:5000:5000"
     volumes:
       # Persiste o banco de dados e os artefatos no disco da VPS.
       # Mesmo que o container seja recriado, o histórico de experimentos é mantido.


### PR DESCRIPTION
…unnel

A porta 5000 do MLflow agora é publicada em 127.0.0.1:5000 da VPS, mantendo o serviço inacessível pela internet (importante porque o MLflow não tem autenticação) mas permitindo acesso à UI por túnel SSH a partir da máquina local:

  ssh -L 5000:localhost:5000 <usuario>@<vps-host>

Os containers train e api continuam usando http://mlflow:5000 pela rede interna do Docker, sem mudança de comportamento.

Documentação atualizada no RUNNING.md com o procedimento de acesso.