### PR TITLE
fix: configura MLFLOW_SERVER_ALLOWED_ORIGINS para liberar CORS na UI …

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,7 +25,6 @@ services:
     # mlflow server cria o schema do banco automaticamente na primeira execução.
     # --allowed-hosts: permite requisições com Host "mlflow" (nome do serviço Docker).
     # O MLflow 2.10+ rejeita por padrão qualquer host que não seja localhost/127.0.0.1.
-    # Seguro porque a porta não está exposta publicamente.
     # --serve-artifacts + --artifacts-destination: o servidor armazena os artefatos
     # em /mlflow/artifacts e os entrega via HTTP usando o esquema mlflow-artifacts://.
     # Importante NÃO usar --default-artifact-root aqui: ele sobrescreve o proxy e
@@ -34,6 +33,12 @@ services:
     # --allowed-hosts inclui "mlflow:5000" porque o header HTTP enviado pelos containers
     # inclui a porta (ex: "Host: mlflow:5000"), e o middleware faz match exato.
     command: mlflow server --backend-store-uri sqlite:////mlflow/mlflow.db --artifacts-destination /mlflow/artifacts --host 0.0.0.0 --port 5000 --serve-artifacts --allowed-hosts mlflow,mlflow:5000,localhost,localhost:5000,127.0.0.1,127.0.0.1:5000,82.29.57.75:5000
+    environment:
+      # MLFLOW_SERVER_ALLOWED_ORIGINS: lista de origens (Origin header com esquema)
+      # autorizadas pelo middleware de CORS do MLflow. Sem isso, o navegador acessa
+      # a UI mas as chamadas AJAX (POST /ajax-api/.../search) retornam 403 com a
+      # mensagem "Blocked cross-origin request from http://82.29.57.75:5000".
+      - MLFLOW_SERVER_ALLOWED_ORIGINS=http://82.29.57.75:5000,http://localhost:5000
     healthcheck:
       # /health só retorna 200 após os workers do Uvicorn estarem prontos (~13s).
       # start_period: 30s garante que o container não é marcado healthy antes disso,


### PR DESCRIPTION
…pública

Com a porta 5000 do MLflow exposta publicamente, o middleware de segurança do MLflow 3.x bloqueia chamadas AJAX da própria UI com o erro "Blocked cross-origin request from http://82.29.57.75:5000", retornando 403 em endpoints como /ajax-api/.../search e impedindo listar experimentos, runs e modelos.

A variável MLFLOW_SERVER_ALLOWED_ORIGINS aceita uma lista comma- separada de origens (esquema + host + porta) que o servidor passa a confiar. Inclui o IP público da VPS e localhost (caso o usuário volte a usar o túnel SSH).

Também removi do comentário a frase "Seguro porque a porta não está exposta publicamente", que ficou obsoleta após a porta passar a ser publicada em 0.0.0.0:5000.