### PR TITLE
fix: corrige nome da env var para MLFLOW_SERVER_CORS_ALLOWED_ORIGINS

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,11 +34,14 @@ services:
     # inclui a porta (ex: "Host: mlflow:5000"), e o middleware faz match exato.
     command: mlflow server --backend-store-uri sqlite:////mlflow/mlflow.db --artifacts-destination /mlflow/artifacts --host 0.0.0.0 --port 5000 --serve-artifacts --allowed-hosts mlflow,mlflow:5000,localhost,localhost:5000,127.0.0.1,127.0.0.1:5000,82.29.57.75:5000
     environment:
-      # MLFLOW_SERVER_ALLOWED_ORIGINS: lista de origens (Origin header com esquema)
-      # autorizadas pelo middleware de CORS do MLflow. Sem isso, o navegador acessa
-      # a UI mas as chamadas AJAX (POST /ajax-api/.../search) retornam 403 com a
+      # MLFLOW_SERVER_CORS_ALLOWED_ORIGINS: lista comma-separada de origens (Origin
+      # header com esquema) autorizadas pelo middleware CORSBlockingMiddleware do
+      # MLflow. Sem isso, requisições POST/PUT/DELETE da UI retornam 403 com a
       # mensagem "Blocked cross-origin request from http://82.29.57.75:5000".
-      - MLFLOW_SERVER_ALLOWED_ORIGINS=http://82.29.57.75:5000,http://localhost:5000
+      # Origens em localhost/127.0.0.1 são liberadas automaticamente por
+      # is_localhost_origin(), por isso o acesso via túnel SSH funciona sem
+      # nenhuma configuração extra.
+      - MLFLOW_SERVER_CORS_ALLOWED_ORIGINS=http://82.29.57.75:5000
     healthcheck:
       # /health só retorna 200 após os workers do Uvicorn estarem prontos (~13s).
       # start_period: 30s garante que o container não é marcado healthy antes disso,


### PR DESCRIPTION
A env var anterior (MLFLOW_SERVER_ALLOWED_ORIGINS) não é lida pelo middleware do MLflow 3.11.1 — o nome real, conforme o código em mlflow/server/security_utils.py, é MLFLOW_SERVER_CORS_ALLOWED_ORIGINS. Por isso a lista de origens permitidas estava sempre vazia e os POST da UI retornavam 403 mesmo com a env var aparentemente configurada.

Outra observação derivada da leitura do código: origens em localhost e 127.0.0.1 são liberadas automaticamente por is_localhost_origin(), o que explica por que o acesso via túnel SSH funciona sem nenhuma configuração extra. Por isso removi http://localhost:5000 da lista — ele não muda comportamento.